### PR TITLE
Enable WAL

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -108,7 +108,11 @@ pub struct SqliteStore {
 
 impl SqliteStore {
     pub fn new_with_pool(pool: Pool<SqliteConnectionManager>, compression_level: Option<i32>) -> Result<Self, Error> {
-        pool.get()?.execute(SCHEMA, params![])?;
+        {
+            let conn = pool.get()?;
+            conn.pragma_update(None, "journal_mode", "wal2")?;
+            conn.execute(SCHEMA, params![])?;
+        }
         let compressor = Compressor::new(compression_level.unwrap_or(DEFAULT_COMPRESSION_LEVEL))?;
         Ok(Self {
             pool,


### PR DESCRIPTION
Seems to perform better [vs baseline](https://github.com/ysimonson/binlog/pull/16), though `push_parallel` is still failing:

```
test sqlite::benches::iter          ... bench:     176,909 ns/iter (+/- 3,573)
test sqlite::benches::push          ... bench:   7,678,272 ns/iter (+/- 3,636,034)
test sqlite::benches::push_parallel ... FAILED
```
