### PR TITLE
[sqlite] Removed global compressor/decompressor

### DIFF
--- a/src/benches.rs
+++ b/src/benches.rs
@@ -23,6 +23,7 @@ macro_rules! bench_store_impl {
     ($code:expr) => {
         define_bench!(push, $code);
         define_bench!(push_parallel, $code);
+        define_bench!(latest, $code);
     };
 }
 
@@ -46,9 +47,10 @@ pub fn push_parallel<S: Store + Clone + 'static>(b: &mut Bencher, store: &S) {
         for i in 1..11 {
             let store = store.clone();
             threads.push(thread::spawn(move || {
-                for j in 1..1001 {
+                let name = Atom::from("bench_push_parallel");
+                for j in 1..101 {
                     let idx = i * j;
-                    let entry = Entry::new_with_timestamp(idx, Atom::from("bench_push_parallel"), vec![1, 2, 3]);
+                    let entry = Entry::new_with_timestamp(idx, name.clone(), vec![1, 2, 3]);
                     store.push(Cow::Owned(entry)).unwrap();
                 }
             }));
@@ -56,6 +58,17 @@ pub fn push_parallel<S: Store + Clone + 'static>(b: &mut Bencher, store: &S) {
         for thread in threads.into_iter() {
             thread.join().unwrap();
         }
+    });
+}
+
+pub fn latest<S: Store + Clone + 'static>(b: &mut Bencher, store: &S) {
+    let name = Atom::from("bench_latest");
+    store
+        .push(Cow::Owned(Entry::new_with_timestamp(1, name.clone(), vec![1, 2, 3])))
+        .unwrap();
+
+    b.iter(|| {
+        store.latest(name.clone()).unwrap();
     });
 }
 

--- a/src/stores/sqlite.rs
+++ b/src/stores/sqlite.rs
@@ -127,7 +127,7 @@ impl SqliteStore {
         }
         Ok(Self {
             pool,
-            compression_level: compression_level.unwrap_or(DEFAULT_COMPRESSION_LEVEL)
+            compression_level: compression_level.unwrap_or(DEFAULT_COMPRESSION_LEVEL),
         })
     }
 


### PR DESCRIPTION
This seems to cause a small perf loss for single-threaded runs, but will likely be much faster for highly parallel workloads.